### PR TITLE
跨域路径默认允许所有

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'paths'                    => [],
+    'paths'                    => ['*'],
     'allowed_origins'          => ['*'],
     'allowed_origins_patterns' => [],
     'allowed_methods'          => ['*'],


### PR DESCRIPTION
当前默认为 `[]` ，安装后默认未允许跨域